### PR TITLE
Support gnome-shell-mobile version 46-mobile.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,5 +6,6 @@
   "shell-version": [
     "45",
     "46"
+    "46-mobile.1"
   ]
 }


### PR DESCRIPTION
As of writing this is the newest release in the changelog of gnome-shell-mobile:

https://gitlab.gnome.org/verdre/gnome-shell-mobile/-/blob/958c55550b539d03cf6eb990b47bbbf9f9ec11b5/CHANGELOG.md

This addresses #2.